### PR TITLE
Add option for lobby muting

### DIFF
--- a/src/main/java/net/clementraynaud/skoice/config/ConfigurationField.java
+++ b/src/main/java/net/clementraynaud/skoice/config/ConfigurationField.java
@@ -32,7 +32,8 @@ public enum ConfigurationField {
     CONFIG_MENU,
     MESSAGE_ID,
     TEXT_CHANNEL_ID,
-    GUILD_ID;
+    GUILD_ID,
+    MUTE_LOBBY;
 
     @Override
     public String toString() {

--- a/src/main/java/net/clementraynaud/skoice/listeners/interaction/SelectMenuListener.java
+++ b/src/main/java/net/clementraynaud/skoice/listeners/interaction/SelectMenuListener.java
@@ -134,6 +134,15 @@ public class SelectMenuListener extends ListenerAdapter {
                         this.plugin.getConfiguration().saveFile();
                         event.editMessage(this.plugin.getConfigurationMenu().update()).queue();
                         break;
+                    case "mute-lobby":
+                        if ("true".equals(event.getSelectedOptions().get(0).getValue())) {
+                            this.plugin.getConfiguration().getFile().set(ConfigurationField.MUTE_LOBBY.toString(), true);
+                        } else if ("false".equals(event.getSelectedOptions().get(0).getValue())) {
+                            this.plugin.getConfiguration().getFile().set(ConfigurationField.MUTE_LOBBY.toString(), false);
+                        }
+                        this.plugin.getConfiguration().saveFile();
+                        event.editMessage(this.plugin.getConfigurationMenu().update()).queue();
+                        break;
                     default:
                         throw new IllegalStateException(this.plugin.getLang().getMessage("logger.exception.unexpected-value", componentId));
                 }

--- a/src/main/java/net/clementraynaud/skoice/menus/Menu.java
+++ b/src/main/java/net/clementraynaud/skoice/menus/Menu.java
@@ -134,6 +134,11 @@ public class Menu {
                         this.plugin.getConfiguration().getFile()
                                 .getBoolean(ConfigurationField.CHANNEL_VISIBILITY.toString()), false);
                 break;
+            case "mute-lobby":
+                this.selectMenu = new ToggleSelectMenu(this.plugin.getLang(), this.name,
+                        this.plugin.getConfiguration().getFile()
+                                .getBoolean(ConfigurationField.MUTE_LOBBY.toString()), true);
+                break;
             default:
                 List<Button> buttons = this.getButtons(customizeRadius);
                 if (!buttons.isEmpty()) {

--- a/src/main/java/net/clementraynaud/skoice/menus/MenuEmoji.java
+++ b/src/main/java/net/clementraynaud/skoice/menus/MenuEmoji.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.entities.Emoji;
 
 public enum MenuEmoji {
     ARROW_FORWARD("U+25B6"),
+    ARROW_RIGHT("U+27A1"),
     CALENDAR_SPIRAL("U+1F5D3"),
     CARD_BOX("U+1F5C3"),
     CHART_WITH_UPWARDS_TREND("U+1F4C8"),

--- a/src/main/java/net/clementraynaud/skoice/menus/MenuEmoji.java
+++ b/src/main/java/net/clementraynaud/skoice/menus/MenuEmoji.java
@@ -46,6 +46,7 @@ public enum MenuEmoji {
     LINK("U+1F517"),
     MAG("U+1F50D"),
     MAP("U+1F5FA"),
+    MUTE("U+1F507"),
     NEWSPAPER("U+1F4F0"),
     NO_ENTRY("U+26D4"),
     PENCIL2("U+270F"),

--- a/src/main/java/net/clementraynaud/skoice/tasks/UpdateNetworksTask.java
+++ b/src/main/java/net/clementraynaud/skoice/tasks/UpdateNetworksTask.java
@@ -62,10 +62,7 @@ public class UpdateNetworksTask implements Task {
             if (lobby == null) {
                 return;
             }
-            boolean muteLobby = this.plugin.getConfiguration().getFile().getBoolean(ConfigurationField.MUTE_LOBBY.toString());
-            if (muteLobby) {
-                this.muteMembers(lobby);
-            }
+            this.muteMembers(lobby);
             Network.getNetworks().removeIf(network -> network.getChannel() == null && network.isInitialized());
             Set<UUID> oldEligiblePlayers = this.plugin.getEligiblePlayers().copy();
             this.plugin.getEligiblePlayers().clear();
@@ -140,10 +137,19 @@ public class UpdateNetworksTask implements Task {
     private void muteMembers(VoiceChannel lobby) {
         Role publicRole = lobby.getGuild().getPublicRole();
         PermissionOverride lobbyPublicRoleOverride = lobby.getPermissionOverride(publicRole);
-        if (lobbyPublicRoleOverride == null) {
-            lobby.createPermissionOverride(publicRole).deny(Permission.VOICE_SPEAK).queue();
-        } else if (!lobbyPublicRoleOverride.getDenied().contains(Permission.VOICE_SPEAK)) {
-            lobbyPublicRoleOverride.getManager().deny(Permission.VOICE_SPEAK).queue();
+        boolean muteLobby = this.plugin.getConfiguration().getFile().getBoolean(ConfigurationField.MUTE_LOBBY.toString());
+        if (muteLobby) {
+            if (lobbyPublicRoleOverride == null) {
+                lobby.createPermissionOverride(publicRole).deny(Permission.VOICE_SPEAK).queue();
+            } else if (!lobbyPublicRoleOverride.getDenied().contains(Permission.VOICE_SPEAK)) {
+                lobbyPublicRoleOverride.getManager().deny(Permission.VOICE_SPEAK).queue();
+            }
+        } else {
+            if (lobbyPublicRoleOverride == null) {
+                lobby.createPermissionOverride(publicRole).grant(Permission.VOICE_SPEAK).queue();
+            } else if (!lobbyPublicRoleOverride.getAllowed().contains(Permission.VOICE_SPEAK)) {
+                lobbyPublicRoleOverride.getManager().grant(Permission.VOICE_SPEAK).queue();
+            }
         }
     }
 

--- a/src/main/java/net/clementraynaud/skoice/tasks/UpdateNetworksTask.java
+++ b/src/main/java/net/clementraynaud/skoice/tasks/UpdateNetworksTask.java
@@ -62,7 +62,10 @@ public class UpdateNetworksTask implements Task {
             if (lobby == null) {
                 return;
             }
-            this.muteMembers(lobby);
+            boolean muteLobby = this.plugin.getConfiguration().getFile().getBoolean(ConfigurationField.MUTE_LOBBY.toString());
+            if (muteLobby) {
+                this.muteMembers(lobby);
+            }
             Network.getNetworks().removeIf(network -> network.getChannel() == null && network.isInitialized());
             Set<UUID> oldEligiblePlayers = this.plugin.getEligiblePlayers().copy();
             this.plugin.getEligiblePlayers().clear();

--- a/src/main/java/net/clementraynaud/skoice/tasks/UpdateVoiceStateTask.java
+++ b/src/main/java/net/clementraynaud/skoice/tasks/UpdateVoiceStateTask.java
@@ -42,8 +42,7 @@ public class UpdateVoiceStateTask implements Task {
 
     @Override
     public void run() {
-        boolean muteLobby = this.configuration.getFile().getBoolean(ConfigurationField.MUTE_LOBBY.toString());
-        if (this.member.getVoiceState() == null || this.configuration.getLobby() == null || !muteLobby) {
+        if (this.member.getVoiceState() == null || this.configuration.getLobby() == null) {
             return;
         }
         boolean isLobby = this.channel.getId().equals(this.configuration.getLobby().getId());
@@ -53,18 +52,19 @@ public class UpdateVoiceStateTask implements Task {
                     && this.member.hasPermission(this.channel, Permission.VOICE_SPEAK, Permission.VOICE_MUTE_OTHERS)
                     && this.channel.getGuild().getSelfMember().hasPermission(this.channel, Permission.VOICE_MUTE_OTHERS)
                     && this.channel.getGuild().getSelfMember().hasPermission(this.configuration.getCategory(), Permission.VOICE_MOVE_OTHERS)) {
-                this.member.mute(true).queue();
-                List<String> mutedUsers = this.configuration.getFile().getStringList(ConfigurationField.MUTED_USERS_ID.toString());
-                mutedUsers.add(this.member.getId());
-                this.configuration.getFile().set(ConfigurationField.MUTED_USERS_ID.toString(), mutedUsers);
+                boolean muteLobby = this.configuration.getFile().getBoolean(ConfigurationField.MUTE_LOBBY.toString());
+                this.member.mute(muteLobby).queue();
+                List<String> usersInLobby = this.configuration.getFile().getStringList(ConfigurationField.MUTED_USERS_ID.toString());
+                usersInLobby.add(this.member.getId());
+                this.configuration.getFile().set(ConfigurationField.MUTED_USERS_ID.toString(), usersInLobby);
                 this.configuration.saveFile();
             }
         } else if (!isLobby) {
-            List<String> mutedUsers = this.configuration.getFile().getStringList(ConfigurationField.MUTED_USERS_ID.toString());
-            if (mutedUsers.contains(this.member.getId())) {
+            List<String> usersInLobby = this.configuration.getFile().getStringList(ConfigurationField.MUTED_USERS_ID.toString());
+            if (usersInLobby.contains(this.member.getId())) {
                 this.member.mute(false).queue();
-                mutedUsers.remove(this.member.getId());
-                this.configuration.getFile().set(ConfigurationField.MUTED_USERS_ID.toString(), mutedUsers);
+                usersInLobby.remove(this.member.getId());
+                this.configuration.getFile().set(ConfigurationField.MUTED_USERS_ID.toString(), usersInLobby);
                 this.configuration.saveFile();
             }
         }

--- a/src/main/java/net/clementraynaud/skoice/tasks/UpdateVoiceStateTask.java
+++ b/src/main/java/net/clementraynaud/skoice/tasks/UpdateVoiceStateTask.java
@@ -42,7 +42,8 @@ public class UpdateVoiceStateTask implements Task {
 
     @Override
     public void run() {
-        if (this.member.getVoiceState() == null || this.configuration.getLobby() == null) {
+        boolean muteLobby = this.configuration.getFile().getBoolean(ConfigurationField.MUTE_LOBBY.toString());
+        if (this.member.getVoiceState() == null || this.configuration.getLobby() == null || !muteLobby) {
             return;
         }
         boolean isLobby = this.channel.getId().equals(this.configuration.getLobby().getId());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,4 @@
 lang: EN
 action-bar-alert: true
 channel-visibility: false
+mute-lobby: true

--- a/src/main/resources/lang/EN.yml
+++ b/src/main/resources/lang/EN.yml
@@ -141,6 +141,9 @@ discord:
       title: "Linking Process"
     error:
       title: "Error"
+    mute-lobby:
+      title: "Mute Lobby"
+      description: "Toggle whether users are muted when in the lobby voice channel."
   field:
     configuration-complete:
       title: "Configuration Complete"

--- a/src/main/resources/lang/EN.yml
+++ b/src/main/resources/lang/EN.yml
@@ -144,6 +144,9 @@ discord:
     mute-lobby:
       title: "Mute Lobby"
       description: "Toggle whether users are muted when in the lobby voice channel."
+    advanced-settings-page-two:
+      title: "Next page"
+      description: "See more parameters to manage."
   field:
     configuration-complete:
       title: "Configuration Complete"

--- a/src/main/resources/lang/FR.yml
+++ b/src/main/resources/lang/FR.yml
@@ -144,6 +144,9 @@ discord:
     mute-lobby:
       title: "[EN Placeholder] Mute Lobby"
       description: "[EN Placeholder] Toggle whether users are muted when in the lobby voice channel."
+    advanced-settings-page-two:
+      title: "[EN Placeholder] Next page"
+      description: "[EN Placeholder] See more parameters to manage."
   field:
     configuration-complete:
       title: "Configuration terminée"

--- a/src/main/resources/lang/FR.yml
+++ b/src/main/resources/lang/FR.yml
@@ -141,6 +141,9 @@ discord:
       title: "Procédure de liaison"
     error:
       title: "Erreur"
+    mute-lobby:
+      title: "[EN Placeholder] Mute Lobby"
+      description: "[EN Placeholder] Toggle whether users are muted when in the lobby voice channel."
   field:
     configuration-complete:
       title: "Configuration terminée"

--- a/src/main/resources/menus/menus.yml
+++ b/src/main/resources/menus/menus.yml
@@ -107,11 +107,21 @@ channel-visibility:
   type: default
   style: primary
   parent: advanced-settings
+advanced-settings-page-two:
+  emoji: arrow_right
+  type: default
+  style: secondary
+  parent: advanced-settings
+mute-lobby:
+  emoji: mute
+  type: default
+  style: primary
+  parent: advanced-settings-page-two
 changelog:
   emoji: newspaper
   type: default
   style: secondary
-  parent: advanced-settings
+  parent: advanced-settings-page-two
   fields:
     - skoice-2-1
     - upcoming-features
@@ -130,8 +140,3 @@ get-the-proximity-voice-chat:
     - donate
     - troubleshooting
     - contribute
-mute-lobby:
-  emoji: mute
-  type: default
-  style: primary
-  parent: advanced-settings

--- a/src/main/resources/menus/menus.yml
+++ b/src/main/resources/menus/menus.yml
@@ -130,3 +130,8 @@ get-the-proximity-voice-chat:
     - donate
     - troubleshooting
     - contribute
+mute-lobby:
+  emoji: mute
+  type: default
+  style: primary
+  parent: advanced-settings


### PR DESCRIPTION
# Lobby Muting
Added a configurable option to have players in the lobby channel muted or unmuted.

### What this does: 
By default, mute-lobby is set to true and use of this plugin is as intended. When mute-lobby is set to false, players in the lobby channel are not muted.

### Issues
1. I do not speak French
   * I added the English for mute-lobby and advanced-settings-page-two as a placeholder in `FR.yml`. This will need to be changed.